### PR TITLE
Add PTR records

### DIFF
--- a/dns/types/records/PTR.nix
+++ b/dns/types/records/PTR.nix
@@ -1,0 +1,25 @@
+#
+# © 2019 Kirill Elagin <kirelagin@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+#
+
+{ pkgs }:
+
+let
+  inherit (pkgs.lib) mkOption types;
+
+in
+
+{
+  rtype = "PTR";
+  options = {
+    cname = mkOption {
+      type = types.str;
+      example = "www.test.com";
+      description = "A <domain-name> which specifies the domain name associated with an IP address";
+    };
+  };
+  dataToString = {ptr, ...}: "${ptr}";
+  fromString = ptr: { inherit ptr; };
+}

--- a/dns/types/records/default.nix
+++ b/dns/types/records/default.nix
@@ -19,6 +19,7 @@ let
     "SOA"
     "SRV"
     "TXT"
+    "PTR"
   ];
 
 in


### PR DESCRIPTION
Simple addition - I'm using Nixops to provision DNS servers with automatic forward and reverse DNS, so I need PTR records as well. Tested and working (see `dig -x 2602:fd64:0:1:226:55ff:fe29:7564`).