### PR TITLE
Support writeZone in flake mode

### DIFF
--- a/dns/default.nix
+++ b/dns/default.nix
@@ -29,10 +29,7 @@ let
     }).config.zones."${name}";
 
   writeZone = name: zone:
-    pkgs.writeTextFile {
-      name = "${name}.zone";
-      text = toString (evalZone name zone);
-    };
+    (pkgs.writeText or builtins.toFile) "${name}.zone" (toString (evalZone name zone));
 in
 
 {


### PR DESCRIPTION
Closes #4. Falls back to using `builtins.toFile` in `writeZone` when `nix-dns` is imported as a flake.

Note that this won't work if the zone definition contains references to derivations, but I don't think this is a plausible enough use case as to deserve documentation.