### PR TITLE
Take `lib` as argument in PTR type

### DIFF
--- a/dns/types/records/PTR.nix
+++ b/dns/types/records/PTR.nix
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: MIT
 #
 
-{ pkgs }:
+{ lib }:
 
 let
-  inherit (pkgs.lib) mkOption types;
+  inherit (lib) mkOption types;
 
 in
 


### PR DESCRIPTION
`lib` is provided as an argument to the record types, not `pkgs`, which meant that a missing required argument would be encountered when using `nix-dns`. Introduced by #8.

https://github.com/kirelagin/nix-dns/blob/bb554091237f959c4e34db958c355d24653bb6b8/dns/types/records/default.nix#L35

cc @kirelagin 