### PR TITLE
Fix useOrigin for rtypes using nameFixup

### DIFF
--- a/dns/types/record.nix
+++ b/dns/types/record.nix
@@ -35,8 +35,8 @@ let
   writeRecord = name: rsubt: data:
     let
       name' = let fname = rsubt.nameFixup or (n: _: n) name data; in
-        if name == "@" then name
-        else if (hasSuffix ".@" name) then removeSuffix ".@" fname
+        if fname == "@" then name
+        else if (hasSuffix ".@" fname) then removeSuffix ".@" fname
         else "${fname}.";
       rtype = rsubt.rtype;
     in lib.concatStringsSep " " (with data; [


### PR DESCRIPTION
As described in `./README.md`, when specifying `useOrigin = true` in a zone, the base domain is not included in every record, but rather only in the `$ORIGIN` statement at the top. Records will use "@" as a shorthand for the domain part.

I think the check for "@"-replacement fails to take `nameFixup` into account when removing the domain part, thus (potentially) breaking SRV, DMARC and DKIM records that add their own formatting/prefix to field names.

It looks like it might have broken in https://github.com/nix-community/dns.nix/commit/e3ad88941c7b1cf4f079a757e8c433571f32228d, that started passing `name` right through.

----

#### Example taken from `./example.nix`

```nix
  SRV = [
      {
        service = "sip";
        proto = "tcp";
        port = 5060;
        target = "sip.example.com";
      }
    ];
```

With `useOrigin=false` (default):

```zone
_sip._tcp.test.com. IN SRV 0 100 5060 sip.example.com
```

With `useOrigin=true`:

```zone
@ IN SRV 0 100 5060 sip.example.com
```

With `useOrigin=true` **and this fix**:

```zone
_sip._tcp IN SRV 0 100 5060 sip.example.com
```

----

Most records do not use `nameFixup`, so `name` and `fname` is the same, and they are not affected by this change. As shown in files generated from example.nix, SRV and DMARC are fixed and the rest is unchanged.

```diff
$ diff result-unfixed-origin result-fixed-origin
16c16
< @ IN TXT "v=DMARC1; p=none; adkim=r; aspf=r; fo=0; pct=100; rf=afrf; ri=86400; rua=mailto:re+abcdefghijk@dmarc.postmarkapp.com; sp=none;"
---
> _dmarc IN TXT "v=DMARC1; p=none; adkim=r; aspf=r; fo=0; pct=100; rf=afrf; ri=86400; rua=mailto:re+abcdefghijk@dmarc.postmarkapp.com; sp=none;"
31c31
< @ IN SRV 0 100 5060 sip.example.com
---
> _sip._tcp IN SRV 0 100 5060 sip.example.com
```

```diff
$ diff result-unfixed-noorigin result-fixed-noorigin

```
