### PR TITLE
records: SRV: add ending dot to target if missing

### DIFF
--- a/dns/types/records/SRV.nix
+++ b/dns/types/records/SRV.nix
@@ -50,7 +50,10 @@ in
     };
   };
   dataToString = data: with data;
-    "${toString priority} ${toString weight} ${toString port} ${target}";
+    let
+      targetHost = if lib.hasSuffix "." target then target else "${target}.";
+    in
+    "${toString priority} ${toString weight} ${toString port} ${targetHost}";
   nameFixup = name: self:
     "_${self.service}._${self.proto}.${name}";
 }


### PR DESCRIPTION
According to RFC 2782, the target domain should always end with a dot.